### PR TITLE
Add support for Sagrid's Custom20 Mounts and bot support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here is a list of compatible modules that you can install with this system:
 - [Paladin power](https://github.com/Redbu11dev/cmangos-paladinpower) (Classic only): A module to give paladins their cut spells back
 - [Classless](https://github.com/flekz-games/cmangos-classless) (Classic only): A module to allow a classless game mode
 - [VoiceOver](https://github.com/flekz-games/cmangos-voiceover) (Classic only): Module to support working with the VoiceOver (AI generated npc voices) addon
+- [Custom20](https://github.com/japtenks/cmangos-custom20) (Classic only): Module to enable Quest/Mounts for Level 20 with bot support. 
 
 # How to install
 NOTE: At the moment there is no officially supported way for installing this system using the stock cmangos source code, however we have prepared two options depending on your skills. This guide assumes that you have knowledge on using git repositories and know how to compile using cmake, if not please refer to the [Beginners Guide](https://github.com/cmangos/issues/wiki/Beginners-Guide-Introduction) for more info.

--- a/modules.conf
+++ b/modules.conf
@@ -12,3 +12,4 @@ CLASSLESS=https://github.com/flekz-games/cmangos-classless.git
 VOICEOVER=https://github.com/flekz-games/cmangos-voiceover.git
 MODULES=https://github.com/flekz-games/cmangos-modules.git
 CUSTOM20=https://github.com/japtenks/cmangos-custom20.git
+EXTRACOMMANDS=https://github.com/japtenks/cmangos-extracommands.git

--- a/modules.conf
+++ b/modules.conf
@@ -11,3 +11,4 @@ BALANCING=https://github.com/flekz-games/cmangos-balancing.git
 CLASSLESS=https://github.com/flekz-games/cmangos-classless.git
 VOICEOVER=https://github.com/flekz-games/cmangos-voiceover.git
 MODULES=https://github.com/flekz-games/cmangos-modules.git
+CUSTOM20=https://github.com/japtenks/cmangos-custom20.git

--- a/src/ModuleMgr.cpp
+++ b/src/ModuleMgr.cpp
@@ -1236,6 +1236,7 @@ namespace cmangos_module
             if (!cmdPrefix.empty() && !cmdSuffix.empty())
             {
                 WorldSession* session = chatHandler->GetSession();
+                uint32 accessLevel = session ? session->GetSecurity() : SEC_CONSOLE;
                 for (Module* mod : modules)
                 {
                     const char* moduleCommandPrefix = mod->GetChatCommandPrefix();
@@ -1246,7 +1247,7 @@ namespace cmangos_module
                         {
                             for (auto chatCommand : *commandTable)
                             {
-                                if (chatCommand.name == cmdSuffix && session->GetSecurity() >= chatCommand.securityLevel)
+                                if (chatCommand.name == cmdSuffix && accessLevel >= chatCommand.securityLevel)
                                 {
                                     return chatCommand.callback(session, cmdArgs);
                                 }


### PR DESCRIPTION
This pull request adds support for the new `Custom20` module, which enables Quest/Mounts for Level 20 with bot support. The changes update both the documentation and the module configuration to include this new module.

Module support updates:

* Added `Custom20` to the list of compatible modules in `README.md`, describing its purpose and providing a link to its repository.
* Added the `CUSTOM20` entry to `modules.conf` to allow installation of the `Custom20` module from its repository.